### PR TITLE
Update the API to latest version

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/instagram/InstagramAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/instagram/InstagramAuthenticator.java
@@ -178,10 +178,8 @@ public class InstagramAuthenticator extends OpenIDConnectAuthenticator implement
             }
             context.setProperty(OIDCAuthenticatorConstants.ACCESS_TOKEN, accessToken);
             AuthenticatedUser authenticatedUserObj = AuthenticatedUser
-                    .createFederateAuthenticatedUserFromSubjectIdentifier(JSONUtils.parseJSON(userObj)
-                            .get(InstagramAuthenticatorConstants.INSTAGRAM_USERNAME).toString());
-            authenticatedUserObj.setAuthenticatedSubjectIdentifier(JSONUtils.parseJSON(userObj)
-                    .get(InstagramAuthenticatorConstants.INSTAGRAM_USERNAME).toString());
+                    .createFederateAuthenticatedUserFromSubjectIdentifier(userObj);
+            authenticatedUserObj.setAuthenticatedSubjectIdentifier(userObj);
             Map<ClaimMapping, String> claims = getSubjectAttributes(oAuthResponse, authenticatorProperties);
             authenticatedUserObj.setUserAttributes(claims);
             context.setSubject(authenticatedUserObj);
@@ -206,14 +204,13 @@ public class InstagramAuthenticator extends OpenIDConnectAuthenticator implement
             String url = getUserInfoEndpoint(userObj, authenticatorProperties);
             String json = sendRequest(url, accessToken);
             JSONObject obj = new JSONObject(json);
-            String userData = obj.getJSONObject("data").toString();
             if (StringUtils.isBlank(json)) {
                 if (log.isDebugEnabled()) {
                     log.debug("Unable to fetch user claims. Proceeding without user claims");
                 }
                 return claims;
             }
-            Map<String, Object> jsonObject = JSONUtils.parseJSON(userData);
+            Map<String, Object> jsonObject = JSONUtils.parseJSON(json);
             for (Map.Entry<String, Object> data : jsonObject.entrySet()) {
                 String key = data.getKey();
                 claims.put(ClaimMapping.build(InstagramAuthenticatorConstants.CLAIM_DIALECT_URI + "/" + key,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/instagram/InstagramAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/instagram/InstagramAuthenticatorConstants.java
@@ -23,14 +23,13 @@ public class InstagramAuthenticatorConstants {
 
     public static final String INSTAGRAM_OAUTH_ENDPOINT = "https://api.instagram.com/oauth/authorize/";
     public static final String INSTAGRAM_TOKEN_ENDPOINT = "https://api.instagram.com/oauth/access_token";
-    public static final String INSTAGRAM_USERINFO_ENDPOINT = "https://api.instagram.com/v1/users/self";
+    public static final String INSTAGRAM_USERINFO_ENDPOINT = "https://graph.instagram.com/me";
 
     public static final String INSTAGRAM_CONNECTOR_FRIENDLY_NAME = "Instagram ";
     public static final String INSTAGRAM_CONNECTOR_NAME = "Instagram";
 
     public static final String HTTP_GET_METHOD = "GET";
-    public static final String INSTAGRAM_USERNAME = "username";
-    public static final String INSTAGRAM_USER = "user";
-    public static final String INSTAGRAM_BASIC_SCOPE = "basic";
+    public static final String INSTAGRAM_USER = "user_id";
+    public static final String INSTAGRAM_BASIC_SCOPE = "user_profile,user_media";
     public static final String CLAIM_DIALECT_URI = "http://wso2.org/instagram/claims";
 }


### PR DESCRIPTION
## Purpose
The Connector version 1.0.1 was implemented with Instagram API version 1 and it returns `no valid scope requested`  error during the token generation. Hence, Updating the connector implementation to latest API version [1]

Demo
[Screencast from 12-10-22 07:35:31.webm](https://user-images.githubusercontent.com/28682701/195241784-c2177348-d41a-4a76-8e91-d62278ee7add.webm)

[1] https://developers.facebook.com/docs/instagram-basic-display-api/getting-started

## Related issue
- https://github.com/wso2/product-is/issues/15025 
