### PR TITLE
Fix duplicated components found error

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -64,19 +64,6 @@
                     </instructions>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-scr-plugin</artifactId>
-                <version>1.26.4</version>
-                <executions>
-                    <execution>
-                        <id>generate-scr-scrdescriptor</id>
-                        <goals>
-                            <goal>scr</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
     <dependencies>


### PR DESCRIPTION
## Purpose
This PR will fix the following server startup error

```
[2023-01-10 18:01:23,775] [] ERROR {org.wso2.carbon.extension.identity.authenticator.instagram.connector} - [SCR] Found components with duplicated names inside their bundle! This component will not be processed: Component[
	name = identity.application.authenticator.Instagram.component
	activate = activate
	deactivate = deactivate
	modified = 
	configuration-policy = optional
	factory = null
	autoenable = true
	immediate = true
	implementation = org.wso2.carbon.identity.authenticator.instagram.internal.InstagramAuthenticatorServiceComponent
	state = Unsatisfied
	properties = 
	serviceFactory = false
	serviceInterface = null
	references = null
	located in bundle = org.wso2.carbon.extension.identity.authenticator.instagram.connector_1.0.2 [232]
] 
```

